### PR TITLE
improvements: cast_batch/2 & batch size settings

### DIFF
--- a/src/gen_batch_server.erl
+++ b/src/gen_batch_server.erl
@@ -30,9 +30,9 @@
               {call, from(), UserOp :: term()} |
               {info, UserOp :: term()}.
 
--record(config, {batch_size = ?MIN_MAX_BATCH_SIZE :: non_neg_integer(),
-                 min_batch_size = ?MIN_MAX_BATCH_SIZE :: non_neg_integer(),
-                 max_batch_size = ?MAX_MAX_BATCH_SIZE :: non_neg_integer(),
+-record(config, {batch_size :: non_neg_integer(),
+                 min_batch_size :: non_neg_integer(),
+                 max_batch_size :: non_neg_integer(),
                  parent :: pid(),
                  name :: atom(),
                  module :: module()}).
@@ -102,12 +102,17 @@ init_it(Starter, self, Name, Mod, Args, Options) ->
 init_it(Starter, Parent, Name0, Mod, Args, Options) ->
     Name = gen:name(Name0),
     Debug = gen:debug_options(Name, Options),
+    MaxBatchSize = proplists:get_value(max_batch_size, Options, ?MAX_MAX_BATCH_SIZE),
+    MinBatchSize = proplists:get_value(min_batch_size, Options, ?MIN_MAX_BATCH_SIZE),
     case catch Mod:init(Args) of
         {ok, State0} ->
             proc_lib:init_ack(Starter, {ok, self()}),
             Conf = #config{module = Mod,
                            parent = Parent,
-                           name = Name},
+                           name = Name,
+                           batch_size = MinBatchSize,
+                           min_batch_size = MinBatchSize,
+                           max_batch_size = MaxBatchSize},
             State = #state{config = Conf,
                            state = State0,
                            debug = Debug},

--- a/src/gen_batch_server.erl
+++ b/src/gen_batch_server.erl
@@ -4,6 +4,8 @@
 -export([start_link/3,
          start_link/4,
          init_it/6,
+         stop/1,
+         stop/3,
          cast/2,
          cast_batch/2,
          call/2,
@@ -140,6 +142,12 @@ init_it(Starter, Parent, Name0, Mod, Args, Options) ->
             proc_lib:init_ack(Starter, {error, Error}),
             exit(Error)
     end.
+
+stop(Name) ->
+    gen:stop(Name).
+
+stop(Name, Reason, Timeout) ->
+    gen:stop(Name, Reason, Timeout).
 
 -spec cast(server_ref(), term()) -> ok.
 cast({global,Name}, Request) ->

--- a/test/gen_batch_server_SUITE.erl
+++ b/test/gen_batch_server_SUITE.erl
@@ -158,7 +158,6 @@ cast_batch(Config) ->
     meck:expect(Mod, handle_batch,
                 fun(Ops, State) ->
                         {cast, {put, K, V}} = lists:last(Ops),
-                        ct:pal("cast_batch: batch size ~b~n", [length(Ops)]),
                         Self ! {done, K, V},
                         {ok, [], maps:put(K, V, State)}
                 end),

--- a/test/gen_batch_server_SUITE.erl
+++ b/test/gen_batch_server_SUITE.erl
@@ -134,7 +134,6 @@ cast_many(Config) ->
     meck:expect(Mod, handle_batch,
                 fun(Ops, State) ->
                         {cast, {put, K, V}} = lists:last(Ops),
-                        ct:pal("cast_many: batch size ~b~n", [length(Ops)]),
                         Self ! {done, K, V},
                         {ok, [], maps:put(K, V, State)}
                 end),


### PR DESCRIPTION
this PR add the following improvements:


* add `gen_batch_server:cast_batch/2` function: like cast but send a batch of messages instead of one message. This allows the aggregation of multiple batches.
* make `min_batch_size` and `max_batch_size` configurable when starting the  batch.
* add `gen_batch_server:stop/{1, 3}`