### PR TITLE
add gen_batch_server:start_link/2

### DIFF
--- a/src/gen_batch_server.erl
+++ b/src/gen_batch_server.erl
@@ -1,7 +1,8 @@
 %% Copyright (c) 2018-Present Pivotal Software, Inc. All Rights Reserved.
 -module(gen_batch_server).
 
--export([start_link/3,
+-export([start_link/2,
+         start_link/3,
          start_link/4,
          init_it/6,
          stop/1,
@@ -80,6 +81,13 @@
 %%%
 %%% API
 %%%
+
+-spec start_link(Mod, Args) -> Result when
+     Mod :: module(),
+     Args :: term(),
+     Result ::  {ok,pid()} | {error, {already_started, pid()}}.
+start_link(Mod, Args) ->
+  gen:start(?MODULE, link, Mod, Args, []).
 
 -spec start_link(Name, Mod, Args) -> Result when
      Name :: {local, atom()} | {global, term()} | {via, atom(), term()},

--- a/test/gen_batch_server_SUITE.erl
+++ b/test/gen_batch_server_SUITE.erl
@@ -22,6 +22,7 @@ all() ->
 all_tests() ->
     [
      start_link_calls_init,
+     simple_start_link_calls_init,
      cast_calls_handle_batch,
      info_calls_handle_batch,
      cast_many,
@@ -72,6 +73,20 @@ start_link_calls_init(Config) ->
                            end),
     Args = [{some_arg, argh}],
     {ok, Pid} = gen_batch_server:start_link({local, Mod}, Mod, Args, []),
+    %% having to wildcard the args as they don't seem to
+    %% validate correctly
+    ?assertEqual(true, meck:called(Mod, init, '_', Pid)),
+    ?assert(meck:validate(Mod)),
+    ok.
+
+simple_start_link_calls_init(Config) ->
+    Mod = ?config(mod, Config),
+    meck:new(Mod, [non_strict]),
+    meck:expect(Mod, init, fun([{some_arg, argh}]) ->
+                                   {ok, #{}}
+                           end),
+    Args = [{some_arg, argh}],
+    {ok, Pid} = gen_batch_server:start_link(Mod, Args),
     %% having to wildcard the args as they don't seem to
     %% validate correctly
     ?assertEqual(true, meck:called(Mod, init, '_', Pid)),


### PR DESCRIPTION
add `gen_batch:start_link(Mod, Args)` to the functions to start a simple
linked process.

fix #8