### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE-MPL-RabbitMQ
+++ b/LICENSE-MPL-RabbitMQ
@@ -437,7 +437,7 @@ EXHIBIT A -Mozilla Public License.
      ``The contents of this file are subject to the Mozilla Public License
      Version 1.1 (the "License"); you may not use this file except in
      compliance with the License. You may obtain a copy of the License at
-     http://www.mozilla.org/MPL/
+     https://www.mozilla.org/MPL/
 
      Software distributed under the License is distributed on an "AS IS"
      basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 A generic batching server for erlang / elixir
 
 
-`gen_batch_server` is a stateful generic server similar to [`gen_server`](http://erlang.org/doc/man/gen_server.html) that instead of processing incoming requests
+`gen_batch_server` is a stateful generic server similar to [`gen_server`](https://erlang.org/doc/man/gen_server.html) that instead of processing incoming requests
 one by one gathers them into batches before the are passed to the behaviour
 implementation.
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://erlang.org/doc/man/gen_server.html (ReadTimeoutException) with 1 occurrences migrated to:  
  https://erlang.org/doc/man/gen_server.html ([https](https://erlang.org/doc/man/gen_server.html) result ConnectTimeoutException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.mozilla.org/MPL/ with 1 occurrences migrated to:  
  https://www.mozilla.org/MPL/ ([https](https://www.mozilla.org/MPL/) result 301).