### PR TITLE
Allow unnamed server to be started with opts

### DIFF
--- a/src/gen_batch_server.erl
+++ b/src/gen_batch_server.erl
@@ -92,31 +92,30 @@
      Args :: term(),
      Result ::  {ok,pid()} | {error, {already_started, pid()}}.
 start_link(Mod, Args) ->
-  gen:start(?MODULE, link, Mod, {[], Args}, []).
+    gen:start(?MODULE, link, Mod, {[], Args}, []).
 
 -spec start_link(Name, Mod, Args) -> Result when
-     Name :: {local, atom()} | {global, term()} | {via, atom(), term()},
+     Name :: {local, atom()} |
+             {global, term()} |
+             {via, atom(), term()} |
+             undefined,
      Mod :: module(),
      Args :: term(),
      Result ::  {ok,pid()} | {error, {already_started, pid()}}.
 start_link(Name, Mod, Args) ->
-    gen:start(?MODULE, link, Name, Mod, {[], Args}, []).
+    gen_start(Name, Mod, Args, []).
 
 -spec start_link(Name, Mod, Args, Options) -> Result when
-     Name :: {local, atom()} | {global, term()} | {via, atom(), term()},
+     Name :: {local, atom()} |
+             {global, term()} |
+             {via, atom(), term()} |
+             undefined,
      Mod :: module(),
      Args :: term(),
      Options :: list(),
      Result ::  {ok,pid()} | {error, {already_started, pid()}}.
 start_link(Name, Mod, Args, Opts0) ->
-    %% filter out gen batch server specific options as the options type in gen
-    %% is closed and dialyzer would complain.
-    {GBOpts, Opts} = lists:splitwith(fun ({Key, _}) ->
-                                             Key == max_batch_size orelse
-                                             Key == min_batch_size orelse
-                                             Key == reversed_batch
-                                     end, Opts0),
-    gen:start(?MODULE, link, Name, Mod, {GBOpts, Args}, Opts).
+    gen_start(Name, Mod, Args, Opts0).
 
 %% pretty much copied wholesale from gen_server
 init_it(Starter, self, Name, Mod, Args, Options) ->
@@ -433,3 +432,23 @@ do_send(Dest, Msg) ->
         error:_ -> ok
     end,
     ok.
+
+gen_start(undefined, Mod, Args, Opts0) ->
+    %% filter out gen batch server specific options as the options type in gen
+    %% is closed and dialyzer would complain.
+    {GBOpts, Opts} = lists:splitwith(fun ({Key, _}) ->
+                                             Key == max_batch_size orelse
+                                             Key == min_batch_size orelse
+                                             Key == reversed_batch
+                                     end, Opts0),
+    gen:start(?MODULE, link, Mod, {GBOpts, Args}, Opts);
+gen_start(Name, Mod, Args, Opts0) ->
+    %% filter out gen batch server specific options as the options type in gen
+    %% is closed and dialyzer would complain.
+    {GBOpts, Opts} = lists:splitwith(fun ({Key, _}) ->
+                                             Key == max_batch_size orelse
+                                             Key == min_batch_size orelse
+                                             Key == reversed_batch
+                                     end, Opts0),
+    gen:start(?MODULE, link, Name, Mod, {GBOpts, Args}, Opts).
+

--- a/test/gen_batch_server_SUITE.erl
+++ b/test/gen_batch_server_SUITE.erl
@@ -76,10 +76,19 @@ start_link_calls_init(Config) ->
                            end),
     Args = [{some_arg, argh}],
     {ok, Pid} = gen_batch_server:start_link({local, Mod}, Mod, Args),
-    %% having to wildcard the args as they don't seem to
-    %% validate correctly
     ?assertEqual(true, meck:called(Mod, init, '_', Pid)),
+    {ok, Pid2} = gen_batch_server:start_link(Mod, Args),
+    ?assertEqual(true, meck:called(Mod, init, '_', Pid2)),
+    {ok, Pid3} = gen_batch_server:start_link(undefined, Mod, Args),
+    ?assertEqual(true, meck:called(Mod, init, '_', Pid3)),
+    Opts = [{reversed_batch, true}],
+    {ok, Pid4} = gen_batch_server:start_link(undefined, Mod, Args, Opts),
+    ?assertEqual(true, meck:called(Mod, init, '_', Pid4)),
     ?assert(meck:validate(Mod)),
+    gen_batch_server:stop(Pid),
+    gen_batch_server:stop(Pid2),
+    gen_batch_server:stop(Pid3),
+    gen_batch_server:stop(Pid4),
     ok.
 
 simple_start_link_calls_init(Config) ->


### PR DESCRIPTION
Because of an unfortunately early API choice we couldn't use
start_link/3 to start an unnamed server as well as providing options so
this change allows the passing of `undefined` instead of the name.