### PR TITLE
Use the standardized ids for the licenses

### DIFF
--- a/src/gen_batch_server.app.src
+++ b/src/gen_batch_server.app.src
@@ -1,6 +1,6 @@
 {application,gen_batch_server,
              [{description,"Generic batching server"},
-              {licenses,["ASL2","MPL2"]},
+              {licenses,["Apache-2.0","MPL-2.0"]},
               {links,[{"github",
                        "https://github.com/rabbitmq/gen-batch-server"}]},
               {vsn,"0.8.8"},


### PR DESCRIPTION
Hi,

I'm using the rebar3_sbom plugin to generate an sbom for our project. Unfortunately the ASL2 and MPL2 are not recognized as valid license names. This should take care of that.

Thanks,

/Sebastian