### PR TITLE
Upgrade to match modern `gen_server` (continuation of #24)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,31 @@
+name: CI
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        otp: ['26', '27', '28']
+    steps:
+      - uses: actions/checkout@v6
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp }}
+          rebar3-version: '3.24'
+      - uses: actions/cache@v4
+        with:
+          path: |
+            _build
+            ~/.cache/rebar3
+          key: ${{ runner.os }}-otp-${{ matrix.otp }}-rebar3-${{ hashFiles('rebar.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-otp-${{ matrix.otp }}-rebar3-
+      - run: epmd -daemon
+      - run: rebar3 ct --sname batch_test
+      - run: rebar3 dialyzer
+      - run: rebar3 xref

--- a/README.md
+++ b/README.md
@@ -89,13 +89,26 @@ The timeout is optional and defaults to 5000ms.
 
     Types:
         Args = term()
-        Result = {ok, State} | {stop, Reason}
-        State = term(),
+        Result = {ok, State} |
+                 {ok, State, {continue, Continue}} |
+                 ignore |
+                 {stop, Reason}
+        State = term()
+        Continue = term()
         Reason = term()
-
 
 Called whenever a `gen_batch_server` is started with the arguments provided
 to `start_link/4`.
+
+Returning `{ok, State, {continue, Continue}}` will cause `handle_continue/2`
+to be called before processing any messages.
+
+Returning `ignore` will cause `start_link` to return `ignore` and the process
+will exit normally without a crash report.
+
+Can be used in scenarios where a `gen_batch_server`
+depends on a resource that can be temporarily
+unavailable (e.g. when a Ra member runs out of disk space).
 
 #### Module:handle_batch(Batch, State) -> Result.
 
@@ -105,7 +118,11 @@ to `start_link/4`.
         Op = {cast, UserOp} |
              {call, from(), UserOp} |
              {info, UserOp}.
-        Result = {ok, State} | {ok, Actions, State} | {stop, Reason}
+        Result = {ok, State} |
+                 {ok, State, {continue, Continue}} |
+                 {ok, Actions, State} |
+                 {ok, Actions, State, {continue, Continue}} |
+                 {stop, Reason}
         State = term()
         From = {Pid :: pid(), Tag :: reference()}
         Action = {reply, From, Msg} | garbage_collect
@@ -114,6 +131,24 @@ to `start_link/4`.
 
 Called whenever a new batch is ready for processing. The implementation can
 optionally return a list of reply actions used to reply to `call` operations.
+
+#### Module:handle_continue(Continue, State) -> Result
+
+    Types:
+        Continue = term()
+        State = term()
+        Result = {ok, NewState} |
+                 {ok, NewState, {continue, NewContinue}} |
+                 {stop, Reason}
+        NewState = term()
+        NewContinue = term()
+        Reason = term()
+
+Optional. Called after `init/1` returns `{ok, State, {continue, Continue}}` or
+after `handle_batch/2` returns with a `{continue, Continue}` tuple.
+
+Most useful for post-`init/2` work that needs
+the server to be registered first.
 
 #### Module:terminate(Reason, State) -> Result
 
@@ -138,4 +173,3 @@ Optional. Used to provide a custom formatting of the user state.
 # Copyright
 
 (c) 2018-2023 Broadcom. All Rights Reserved. The term Broadcom refers to Broadcom Inc. and/or its subsidiaries.
-

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{minimum_otp_vsn, "22.3"}.
+{minimum_otp_vsn, "26"}.
 {deps, []}.
 {project_plugins, [rebar3_hex]}.
 {profiles,

--- a/src/gen_batch_server.app.src
+++ b/src/gen_batch_server.app.src
@@ -3,7 +3,7 @@
               {licenses,["Apache-2.0","MPL-2.0"]},
               {links,[{"github",
                        "https://github.com/rabbitmq/gen-batch-server"}]},
-              {vsn,"0.8.9"},
+              {vsn,"0.9.0"},
               {modules,[gen_batch_server]},
               {registered,[]},
               {applications,[kernel,stdlib]},

--- a/src/gen_batch_server.erl
+++ b/src/gen_batch_server.erl
@@ -70,7 +70,9 @@
 -callback init(Args :: term()) ->
     {ok, State} |
     {ok, State, {continue, term()}} |
-    {stop, Reason :: term()}
+    ignore |
+    {stop, Reason :: term()} |
+    {error, Reason :: term()}
       when State :: term().
 
 -callback handle_batch([op()], State) ->
@@ -148,21 +150,21 @@ init_it(Starter, Parent, Name0, Mod, {GBOpts, Args}, Options) ->
                    max_batch_size = MaxBatchSize,
                    hibernate_after = HibernateAfter,
                    reversed_batch = ReverseBatch},
-    case catch Mod:init(Args) of
-        {ok, Inner0} ->
+    case init_it(Mod, Args) of
+        {ok, {ok, Inner0}} ->
             proc_lib:init_ack(Starter, {ok, self()}),
             State = #state{config = Conf,
                            state = Inner0,
                            debug = Debug},
             loop_wait(State, Parent);
-        {ok, Inner0, {continue, Continue}} ->
+        {ok, {ok, Inner0, {continue, Continue}}} ->
             proc_lib:init_ack(Starter, {ok, self()}),
             State0 = #state{config = Conf,
                             state = Inner0,
                             debug = Debug},
             State = handle_continue(Continue, State0),
             loop_wait(State, Parent);
-        {stop, Reason} ->
+        {ok, {stop, Reason}} ->
             %% For consistency, we must make sure that the
             %% registered name (if any) is unregistered before
             %% the parent process is notified about the failure.
@@ -170,20 +172,29 @@ init_it(Starter, Parent, Name0, Mod, {GBOpts, Args}, Options) ->
             %% an 'already_started' error if it immediately
             %% tried starting the process again.)
             gen:unregister_name(Name0),
-            proc_lib:init_ack(Starter, {error, Reason}),
             exit(Reason);
-        % ignore ->
-        %     gen:unregister_name(Name0),
-        %     proc_lib:init_ack(Starter, ignore),
-        %     exit(normal);
-        {'EXIT', Reason} ->
+        {ok, {error, _Reason} = Error} ->
+            %% The point of this clause is that we shall have a silent/graceful
+            %% termination. The error reason will be returned to the
+            %% 'Starter' ({error, Reason}), but *no* crash report.
             gen:unregister_name(Name0),
-            proc_lib:init_ack(Starter, {error, Reason}),
-            exit(Reason);
-        Else ->
-            Error = {bad_return_value, Else},
-            proc_lib:init_ack(Starter, {error, Error}),
-            exit(Error)
+            proc_lib:init_fail(Starter, Error, {exit, normal});
+        {ok, ignore} ->
+            gen:unregister_name(Name0),
+            proc_lib:init_fail(Starter, ignore, {exit, normal});
+        {ok, Else} ->
+            gen:unregister_name(Name0),
+            exit({bad_return_value, Else});
+        {'EXIT', Class, Reason, Stacktrace} ->
+            gen:unregister_name(Name0),
+            erlang:raise(Class, Reason, Stacktrace)
+    end.
+init_it(Mod, Args) ->
+    try
+        {ok, Mod:init(Args)}
+    catch
+        throw:R -> {ok, R};
+        Class:R:S -> {'EXIT', Class, R, S}
     end.
 
 stop(Name) ->

--- a/src/gen_batch_server.erl
+++ b/src/gen_batch_server.erl
@@ -103,7 +103,7 @@
 -spec start_link(Mod, Args) -> Result when
      Mod :: module(),
      Args :: term(),
-     Result ::  {ok,pid()} | {error, Reason :: term()}.
+     Result ::  {ok,pid()} | ignore | {error, Reason :: term()}.
 start_link(Mod, Args) ->
     gen:start(?MODULE, link, Mod, {[], Args}, []).
 
@@ -114,7 +114,7 @@ start_link(Mod, Args) ->
              undefined,
      Mod :: module(),
      Args :: term(),
-     Result ::  {ok,pid()} | {error, Reason :: term()}.
+     Result ::  {ok,pid()} | ignore | {error, Reason :: term()}.
 start_link(Name, Mod, Args) ->
     gen_start(Name, Mod, Args, []).
 
@@ -126,7 +126,7 @@ start_link(Name, Mod, Args) ->
      Mod :: module(),
      Args :: term(),
      Options :: list(),
-     Result ::  {ok,pid()} | {error, Reason :: term()}.
+     Result ::  {ok,pid()} | ignore | {error, Reason :: term()}.
 start_link(Name, Mod, Args, Opts0) ->
     gen_start(Name, Mod, Args, Opts0).
 
@@ -375,7 +375,7 @@ complete_batch(#state{batch = Batch0,
                     Batch0
             end,
 
-    case catch Mod:handle_batch(Batch, Inner0) of
+    try Mod:handle_batch(Batch, Inner0) of
         {ok, Inner} ->
             State0#state{batch = [],
                          state = Inner,
@@ -402,10 +402,14 @@ complete_batch(#state{batch = Batch0,
                                          debug = Debug});
         {stop, Reason} ->
             terminate(Reason, State0),
-            exit(Reason);
-        {'EXIT', Reason} ->
-            terminate(Reason, State0),
             exit(Reason)
+    catch
+        throw:Reason ->
+            terminate(Reason, State0),
+            exit(Reason);
+        Class:Reason:Stacktrace ->
+            terminate(Reason, State0),
+            erlang:raise(Class, Reason, Stacktrace)
     end.
 
 handle_actions(Actions, Debug0) ->
@@ -421,17 +425,21 @@ handle_actions(Actions, Debug0) ->
 
 handle_continue(Continue, #state{config = #config{module = Mod},
                                  state = Inner0} = State0) ->
-    case catch Mod:handle_continue(Continue, Inner0) of
+    try Mod:handle_continue(Continue, Inner0) of
         {ok, Inner} ->
             State0#state{state = Inner};
-        {ok, Inner, {continue, Continue}} ->
-            handle_continue(Continue, State0#state{state = Inner});
+        {ok, Inner, {continue, NextContinue}} ->
+            handle_continue(NextContinue, State0#state{state = Inner});
         {stop, Reason} ->
             terminate(Reason, State0),
-            exit(Reason);
-        {'EXIT', Reason} ->
-            terminate(Reason, State0),
             exit(Reason)
+    catch
+        throw:Reason ->
+            terminate(Reason, State0),
+            exit(Reason);
+        Class:Reason:Stacktrace ->
+            terminate(Reason, State0),
+            erlang:raise(Class, Reason, Stacktrace)
     end.
 
 handle_debug_in(#state{debug = Dbg0} = State, Msg) ->

--- a/src/gen_batch_server.erl
+++ b/src/gen_batch_server.erl
@@ -35,7 +35,7 @@
 
 -type from() :: {Pid :: pid(), Tag :: reference()}.
 
--type op() :: {cast, pid(), UserOp :: term()} |
+-type op() :: {cast, UserOp :: term()} |
               {call, from(), UserOp :: term()} |
               {info, UserOp :: term()}.
 
@@ -45,7 +45,7 @@
                  parent :: pid(),
                  name :: atom(),
                  module :: module(),
-                 hibernate_after = infinity :: non_neg_integer(),
+                 hibernate_after = infinity :: non_neg_integer() | infinity,
                  reversed_batch = false :: boolean()}).
 
 -record(state, {batch = [] :: [op()],
@@ -83,7 +83,11 @@
     {stop, Reason :: term()}
       when State :: term().
 
--callback handle_continue(Continue :: term(), State :: term()) -> term().
+-callback handle_continue(Continue :: term(), State) ->
+    {ok, State} |
+    {ok, State, {continue, term()}} |
+    {stop, Reason :: term()}
+      when State :: term().
 
 -callback terminate(Reason :: term(), State :: term()) -> term().
 
@@ -255,7 +259,7 @@ cast_batch_msg(_) ->
 call(Name, Request) ->
     call(Name, Request, 5000).
 
--spec call(pid() | atom(), term(), non_neg_integer() | infinity) -> term().
+-spec call(server_ref(), term(), non_neg_integer() | infinity) -> term().
 call(Name, Request, Timeout) ->
     case catch gen:call(Name, '$gen_call', Request, Timeout) of
         {ok, Res} ->
@@ -347,7 +351,7 @@ loop_batched(#state{debug = Debug} = State0, Parent) ->
               State = complete_batch(State0),
               Config = State#state.config,
               NewBatchSize = max(Config#config.min_batch_size,
-                                 Config#config.batch_size / 2),
+                                 Config#config.batch_size div 2),
               loop_wait(State#state{config =
                                     Config#config{batch_size = NewBatchSize}},
                         Parent)
@@ -376,41 +380,42 @@ complete_batch(#state{batch = Batch0,
             end,
 
     try Mod:handle_batch(Batch, Inner0) of
-        {ok, Inner} ->
-            State0#state{batch = [],
-                         state = Inner,
-                         batch_count = 0};
-        {ok, Inner, {continue, Continue}} ->
-            handle_continue(Continue,
-                            State0#state{batch = [],
-                                         state = Inner,
-                                         batch_count = 0});
-        {ok, Actions, Inner} when is_list(Actions) ->
-            {ShouldGc, Debug} = handle_actions(Actions, Debug0),
-            State0#state{batch = [],
-                         batch_count = 0,
-                         state = Inner,
-                         needs_gc = ShouldGc,
-                         debug = Debug};
-        {ok, Actions, Inner, {continue, Continue}} when is_list(Actions) ->
-            {ShouldGc, Debug} = handle_actions(Actions, Debug0),
-            handle_continue(Continue,
-                            State0#state{batch = [],
-                                         batch_count = 0,
-                                         state = Inner,
-                                         needs_gc = ShouldGc,
-                                         debug = Debug});
-        {stop, Reason} ->
-            terminate(Reason, State0),
-            exit(Reason)
+        Result -> handle_batch_result(Result, State0, Debug0)
     catch
-        throw:Reason ->
-            terminate(Reason, State0),
-            exit(Reason);
+        throw:Result ->
+            handle_batch_result(Result, State0, Debug0);
         Class:Reason:Stacktrace ->
             terminate(Reason, State0),
             erlang:raise(Class, Reason, Stacktrace)
     end.
+
+handle_batch_result({ok, Inner}, State0, _Debug0) ->
+    State0#state{batch = [],
+                 state = Inner,
+                 batch_count = 0};
+handle_batch_result({ok, Inner, {continue, Continue}}, State0, _Debug0) ->
+    handle_continue(Continue,
+                    State0#state{batch = [],
+                                 state = Inner,
+                                 batch_count = 0});
+handle_batch_result({ok, Actions, Inner}, State0, Debug0) when is_list(Actions) ->
+    {ShouldGc, Debug} = handle_actions(Actions, Debug0),
+    State0#state{batch = [],
+                 batch_count = 0,
+                 state = Inner,
+                 needs_gc = ShouldGc,
+                 debug = Debug};
+handle_batch_result({ok, Actions, Inner, {continue, Continue}}, State0, Debug0) when is_list(Actions) ->
+    {ShouldGc, Debug} = handle_actions(Actions, Debug0),
+    handle_continue(Continue,
+                    State0#state{batch = [],
+                                 batch_count = 0,
+                                 state = Inner,
+                                 needs_gc = ShouldGc,
+                                 debug = Debug});
+handle_batch_result({stop, Reason}, State0, _Debug0) ->
+    terminate(Reason, State0),
+    exit(Reason).
 
 handle_actions(Actions, Debug0) ->
     lists:foldl(fun ({reply, {Pid, Tag}, Msg},
@@ -426,21 +431,22 @@ handle_actions(Actions, Debug0) ->
 handle_continue(Continue, #state{config = #config{module = Mod},
                                  state = Inner0} = State0) ->
     try Mod:handle_continue(Continue, Inner0) of
-        {ok, Inner} ->
-            State0#state{state = Inner};
-        {ok, Inner, {continue, NextContinue}} ->
-            handle_continue(NextContinue, State0#state{state = Inner});
-        {stop, Reason} ->
-            terminate(Reason, State0),
-            exit(Reason)
+        Result -> handle_continue_result(Result, State0)
     catch
-        throw:Reason ->
-            terminate(Reason, State0),
-            exit(Reason);
+        throw:Result ->
+            handle_continue_result(Result, State0);
         Class:Reason:Stacktrace ->
             terminate(Reason, State0),
             erlang:raise(Class, Reason, Stacktrace)
     end.
+
+handle_continue_result({ok, Inner}, State0) ->
+    State0#state{state = Inner};
+handle_continue_result({ok, Inner, {continue, NextContinue}}, State0) ->
+    handle_continue(NextContinue, State0#state{state = Inner});
+handle_continue_result({stop, Reason}, State0) ->
+    terminate(Reason, State0),
+    exit(Reason).
 
 handle_debug_in(#state{debug = Dbg0} = State, Msg) ->
     Dbg = sys:handle_debug(Dbg0, fun write_debug/3, ?MODULE, {in, Msg}),
@@ -479,12 +485,12 @@ format_status(_Reason, [_PDict, SysState, Parent, Debug,
        {"Status", SysState},
        {"Parent", Parent},
        {"Logged Events", Log}]} |
-     case catch Mod:format_status(State) of
+     try Mod:format_status(State) of
          L when is_list(L) -> L;
-         {'EXIT', {undef, _}} ->
-             %% not implemented just return the state
-             [State];
          T -> [T]
+     catch
+         error:undef:_ -> [State];
+         _:_ -> [State]
      end].
 
 sys_get_log(Debug) ->
@@ -505,19 +511,21 @@ do_send(Dest, Msg) ->
 gen_start(undefined, Mod, Args, Opts0) ->
     %% filter out gen batch server specific options as the options type in gen
     %% is closed and dialyzer would complain.
-    {GBOpts, Opts} = lists:splitwith(fun ({Key, _}) ->
+    {GBOpts, Opts} = lists:partition(fun ({Key, _}) ->
                                              Key == max_batch_size orelse
                                              Key == min_batch_size orelse
-                                             Key == reversed_batch
+                                             Key == reversed_batch;
+                                         (_) -> false
                                      end, Opts0),
     gen:start(?MODULE, link, Mod, {GBOpts, Args}, Opts);
 gen_start(Name, Mod, Args, Opts0) ->
     %% filter out gen batch server specific options as the options type in gen
     %% is closed and dialyzer would complain.
-    {GBOpts, Opts} = lists:splitwith(fun ({Key, _}) ->
+    {GBOpts, Opts} = lists:partition(fun ({Key, _}) ->
                                              Key == max_batch_size orelse
                                              Key == min_batch_size orelse
-                                             Key == reversed_batch
+                                             Key == reversed_batch;
+                                         (_) -> false
                                      end, Opts0),
     gen:start(?MODULE, link, Name, Mod, {GBOpts, Args}, Opts).
 

--- a/test/gen_batch_server_SUITE.erl
+++ b/test/gen_batch_server_SUITE.erl
@@ -38,7 +38,12 @@ all_tests() ->
      format_status_is_optional,
      max_batch_size,
      stop_calls_terminate,
-     process_hibernates
+     process_hibernates,
+     init_ignore,
+     init_ignore_named,
+     init_error,
+     init_bad_return,
+     init_exception
     ].
 
 groups() ->
@@ -481,6 +486,53 @@ stop_calls_terminate(Config) ->
     timer:sleep(10),
     ?assertEqual(true, meck:called(Mod, terminate, '_')),
     ?assert(meck:validate(Mod)),
+    ok.
+
+init_ignore(Config) ->
+    Mod = ?config(mod, Config),
+    process_flag(trap_exit, true),
+    meck:new(Mod, [non_strict]),
+    meck:expect(Mod, init, fun(_) -> ignore end),
+    ignore = gen_batch_server:start_link(Mod, []),
+    ?assert(meck:validate(Mod)),
+    ok.
+
+init_ignore_named(Config) ->
+    Mod = ?config(mod, Config),
+    process_flag(trap_exit, true),
+    meck:new(Mod, [non_strict]),
+    meck:expect(Mod, init, fun(_) -> ignore end),
+    ignore = gen_batch_server:start_link({local, Mod}, Mod, []),
+    %% name should be unregistered
+    ?assertEqual(undefined, whereis(Mod)),
+    ?assert(meck:validate(Mod)),
+    ok.
+
+init_error(Config) ->
+    Mod = ?config(mod, Config),
+    process_flag(trap_exit, true),
+    meck:new(Mod, [non_strict]),
+    meck:expect(Mod, init, fun(_) -> {error, no_disk} end),
+    {error, no_disk} = gen_batch_server:start_link(Mod, []),
+    ?assert(meck:validate(Mod)),
+    ok.
+
+init_bad_return(Config) ->
+    Mod = ?config(mod, Config),
+    process_flag(trap_exit, true),
+    meck:new(Mod, [non_strict]),
+    meck:expect(Mod, init, fun(_) -> wat end),
+    {error, {bad_return_value, wat}} = gen_batch_server:start_link(Mod, []),
+    ok.
+
+init_exception(Config) ->
+    Mod = ?config(mod, Config),
+    process_flag(trap_exit, true),
+    meck:new(Mod, [non_strict]),
+    meck:expect(Mod, init, fun(_) -> error(boom) end),
+    Result = gen_batch_server:start_link(Mod, []),
+    %% error:boom re-raised via erlang:raise; proc_lib reports {boom, Stack}
+    ?assertMatch({error, {boom, _Stacktrace}}, Result),
     ok.
 
 %% Utility

--- a/test/gen_batch_server_SUITE.erl
+++ b/test/gen_batch_server_SUITE.erl
@@ -42,8 +42,12 @@ all_tests() ->
      init_ignore,
      init_ignore_named,
      init_error,
+     init_stop,
      init_bad_return,
-     init_exception
+     init_exception,
+     handle_continue_stop,
+     handle_continue_chained,
+     opts_not_at_front
     ].
 
 groups() ->
@@ -517,12 +521,22 @@ init_error(Config) ->
     ?assert(meck:validate(Mod)),
     ok.
 
+init_stop(Config) ->
+    Mod = ?config(mod, Config),
+    process_flag(trap_exit, true),
+    meck:new(Mod, [non_strict]),
+    meck:expect(Mod, init, fun(_) -> {stop, go_away} end),
+    {error, go_away} = gen_batch_server:start_link(Mod, []),
+    ?assert(meck:validate(Mod)),
+    ok.
+
 init_bad_return(Config) ->
     Mod = ?config(mod, Config),
     process_flag(trap_exit, true),
     meck:new(Mod, [non_strict]),
     meck:expect(Mod, init, fun(_) -> wat end),
     {error, {bad_return_value, wat}} = gen_batch_server:start_link(Mod, []),
+    ?assert(meck:validate(Mod)),
     ok.
 
 init_exception(Config) ->
@@ -533,7 +547,79 @@ init_exception(Config) ->
     Result = gen_batch_server:start_link(Mod, []),
     %% error:boom re-raised via erlang:raise; proc_lib reports {boom, Stack}
     ?assertMatch({error, {boom, _Stacktrace}}, Result),
+    %% meck:validate would fail here because init raised an exception,
+    %% which meck counts as an unexpected error
     ok.
+
+handle_continue_stop(Config) ->
+    Mod = ?config(mod, Config),
+    process_flag(trap_exit, true),
+    meck:new(Mod, [non_strict]),
+    meck:expect(Mod, init, fun(_) -> {ok, #{}} end),
+    meck:expect(Mod, handle_batch, fun(_Batch, State) ->
+                                           {ok, State, {continue, go}}
+                                   end),
+    meck:expect(Mod, handle_continue, fun(go, _State) ->
+                                              {stop, from_continue}
+                                      end),
+    meck:expect(Mod, terminate, fun(from_continue, _S) -> ok end),
+    {ok, Pid} = gen_batch_server:start_link(Mod, []),
+    ok = gen_batch_server:cast(Pid, msg),
+    receive {'EXIT', Pid, from_continue} -> ok after 2000 -> exit(timeout) end,
+    timer:sleep(10),
+    ?assertEqual(true, meck:called(Mod, terminate, '_')),
+    ?assert(meck:validate(Mod)),
+    ok.
+
+handle_continue_chained(Config) ->
+    Self = self(),
+    Mod = ?config(mod, Config),
+    meck:new(Mod, [non_strict]),
+    meck:expect(Mod, init, fun(_) -> {ok, 0, {continue, first}} end),
+    meck:expect(Mod, handle_continue,
+                fun(first, N) ->
+                        Self ! {continue, first, N},
+                        {ok, N + 1, {continue, second}};
+                   (second, N) ->
+                        Self ! {continue, second, N},
+                        {ok, N + 1}
+                end),
+    {ok, _Pid} = gen_batch_server:start_link(Mod, []),
+    receive {continue, first, 0} -> ok after 2000 -> exit(timeout) end,
+    receive {continue, second, 1} -> ok after 2000 -> exit(timeout) end,
+    ?assert(meck:validate(Mod)),
+    ok.
+
+opts_not_at_front(Config) ->
+    %% Verify gen_batch_server options work even when not at the front of the list
+    Mod = ?config(mod, Config),
+    Self = self(),
+    meck:new(Mod, [non_strict]),
+    meck:expect(Mod, init, fun(_) -> {ok, #{}} end),
+    meck:expect(Mod, handle_batch,
+                fun(Ops, State) ->
+                        Self ! {batch_size, length(Ops)},
+                        {ok, State}
+                end),
+    %% hibernate_after (a gen option) comes before max_batch_size (a gb option)
+    Opts = [{hibernate_after, 5000}, {max_batch_size, 64}],
+    {ok, Pid} = gen_batch_server:start_link(undefined, Mod, [], Opts),
+    %% send more than 64 messages; with max_batch_size=64 they should be
+    %% split into multiple batches (none bigger than 64)
+    [gen_batch_server:cast(Pid, I) || I <- lists:seq(1, 200)],
+    timer:sleep(100),
+    %% collect all batch sizes
+    Sizes = collect_batch_sizes([]),
+    ?assert(lists:all(fun(S) -> S =< 64 end, Sizes)),
+    ?assert(meck:validate(Mod)),
+    ok.
+
+collect_batch_sizes(Acc) ->
+    receive
+        {batch_size, N} -> collect_batch_sizes([N | Acc])
+    after 0 ->
+              lists:reverse(Acc)
+    end.
 
 %% Utility
 wait_batch() ->


### PR DESCRIPTION
This is a continuation to #24 by @the-mikedavis with a few changes from me:

1. Tests (even though they are mock-based ones 😢)
2. More tests
3. Refactoring, including an unexpected throughput gain (see below)
4. `README.md` doc updates
5. A drive-by change in `gen_start/4` where `splitwith/2` incorrectly could leave some options behind, so it now uses `partition/2`
6. This version handles single atom options (that Team RabbitMQ rarely uses but this is a generic open source library)

## Benchmarks

Since this library is used on the hot code path in RabbitMQ, I figured benchmarking the changes is a must.

The benchmark demonstrate a 4% to 9% gain:

 * `cast` workloads gain 4-5% in terms of throughput (the RabbitMQ/Ra workloads fall into this category)
 * `call` workloads gain up to 8-9% with comparably lower latency
 * `cast_batch`, perhaps as expected, gains meager 0.1% because batching largely eliminates per-operation gains

## Where Do the Gains Come From?

Apparently the modern JIT optimises the `try/catch` ops better than `case catch`.

But curiously an even nicer gain comes from a switch in `loop_batched/2` where `/ 2` was replaced with `div 2`: the former produces an intermediary float for every call while the latter does not, eliminating a few wasted CPU cycles and memory churn.

Nice! Thank you, @the-mikedavis!

## RabbitMQ, Ra Compatibility

These changes should be compatible with RabbitMQ branches going back to `v3.13.x`:

 * `v3.13.x` uses `call/3`
 * `v4.0.x` through `main` use (via Ra and Osiris) 2-tuple casts on the key code paths