### PR TITLE
Flush mailbox before exit to prevent OOM during crash report formatting

### DIFF
--- a/src/gen_batch_server.erl
+++ b/src/gen_batch_server.erl
@@ -289,6 +289,7 @@ loop_wait(#state{config = #config{hibernate_after = Hib}} = State00, Parent) ->
                                           ?MODULE, State0#state.debug, State0);
                 {'EXIT', Parent, Reason} ->
                     terminate(Reason, State0),
+                    flush_mailbox(),
                     exit(Reason);
                 _ ->
                     enter_loop_batched(Msg, Parent, State0)
@@ -343,6 +344,7 @@ loop_batched(#state{debug = Debug} = State0, Parent) ->
                                           ?MODULE, Debug, State0);
                 {'EXIT', Parent, Reason} ->
                     terminate(Reason, State0),
+                    flush_mailbox(),
                     exit(Reason);
                 _ ->
                     enter_loop_batched(Msg, Parent, State0)
@@ -386,6 +388,7 @@ complete_batch(#state{batch = Batch0,
             handle_batch_result(Result, State0, Debug0);
         Class:Reason:Stacktrace ->
             terminate(Reason, State0),
+            flush_mailbox(),
             erlang:raise(Class, Reason, safe_stacktrace(Stacktrace))
     end.
 
@@ -415,6 +418,7 @@ handle_batch_result({ok, Actions, Inner, {continue, Continue}}, State0, Debug0) 
                                  debug = Debug});
 handle_batch_result({stop, Reason}, State0, _Debug0) ->
     terminate(Reason, State0),
+    flush_mailbox(),
     exit(Reason).
 
 handle_actions(Actions, Debug0) ->
@@ -437,6 +441,7 @@ handle_continue(Continue, #state{config = #config{module = Mod},
             handle_continue_result(Result, State0);
         Class:Reason:Stacktrace ->
             terminate(Reason, State0),
+            flush_mailbox(),
             erlang:raise(Class, Reason, safe_stacktrace(Stacktrace))
     end.
 
@@ -446,6 +451,7 @@ handle_continue_result({ok, Inner, {continue, NextContinue}}, State0) ->
     handle_continue(NextContinue, State0#state{state = Inner});
 handle_continue_result({stop, Reason}, State0) ->
     terminate(Reason, State0),
+    flush_mailbox(),
     exit(Reason).
 
 handle_debug_in(#state{debug = Dbg0} = State, Msg) ->
@@ -467,6 +473,7 @@ system_continue(Parent, Debug, State) ->
 -spec system_terminate(term(), pid(), list(), term()) -> no_return().
 system_terminate(Reason, _Parent, _Debug, State) ->
     terminate(Reason, State),
+    flush_mailbox(),
     exit(Reason).
 
 system_get_state(State) ->
@@ -498,8 +505,6 @@ sys_get_log(Debug) ->
 
 write_debug(Dev, Event, Name) ->
     io:format(Dev, "~p event = ~p~n", [Name, Event]).
-
-%% Send function
 
 do_send(Dest, Msg) ->
     try erlang:send(Dest, Msg)
@@ -538,3 +543,11 @@ safe_stacktrace(Stacktrace) ->
                  (Frame) ->
                       Frame
               end, Stacktrace).
+
+%% Flush all messages from the mailbox. This prevents proc_lib crash reports
+%% from pretty-printing potentially large messages (e.g. WAL write commands
+%% containing binary payloads), which can cause unbounded memory growth.
+flush_mailbox() ->
+    receive _ -> flush_mailbox()
+    after 0 -> ok
+    end.


### PR DESCRIPTION
 ### What?

When a gen_batch_server process exits abnormally, proc_lib:exit_p/3 generates a crash report that includes the process mailbox contents (via proc_lib:get_messages/1). The default OTP logger handler then formats this crash report in the dying process itself (logger_h_common:log_to_binary/2) using io_lib_pretty with potentially unlimited depth and character limits.

For high-throughput gen_batch_server processes like the Ra WAL, the mailbox can contain thousands of messages with large binary payloads (e.g. AMQP message bodies). Pretty-printing these binaries byte-by-byte via io_lib_pretty:print_length_binary causes unbounded memory growth, observed at 10-25+ GB before the node runs out of memory.

The fix drains the mailbox after terminate/2 but before exit/1 or erlang:raise/3 on every exit path. This way proc_lib's crash report finds an empty mailbox, keeping the report small. The exit reason semantics are preserved so supervisors still see the abnormal exit and restart the process normally.

 ### Repro steps

**Without** this commit, the following repro steps caused RabbitMQ nodes to run out of memory. In tanzu-rabbitmq:
1. put `rabbit_chaos` module in `deps/rabbit/src/`
2. `make start-cluster NODES=3 ENABLED_PLUGINS="rabbitmq_jms_management" FULL=1`
3. 
```
omq amqp --uri amqp://localhost:5672/,amqp://localhost:5673/,amqp://localhost:5674/ \
                     --queues jms --queue-args 'x-selector-fields=*',x-queue-leader-locator=balanced \
                     -t /queues/jmsq-%d -T /queues/jmsq-%d -s '{{ randInt 1000 100000 }}' \
                     -x 10 -y 9 --consumer-credits 1000 \
                     --amqp-app-property 'color=red,blue,green,yellow' -c  1000 \
                     --amqp-jms-selector "color <> 'red'"
```
4.
```
for i in 1 2 3; do rabbitmqctl -n rabbit-$i eval 'rabbit_chaos:begin_jms_chaos().'; done
```

After 30-90 seconds, process memory of `ra_jms_queues_log_wal` grew huge (several GBs).

This process had the following stacktrace:
```
./sbin/rabbitmqctl -n rabbit-3 eval 'Pid = whereis(ra_jms_queues_log_wal), erlang:process_info(Pid, [current_function, current_location, current_stacktrace, initial_call, message_queue_len, registered_name, status,stack_size, backtrace]).'
```
shows the following:
```
[{current_function,{lists,reverse,2}},
 {current_location,{lists,reverse,2,[]}},
 {current_stacktrace,[{lists,reverse,1,[{file,"lists.erl"},{line,298}]},
                      {io_lib,write_binary,3,[{file,"io_lib.erl"},{line,860}]},
                      {io_lib_pretty,print_length_binary,7,
                                     [{file,"io_lib_pretty.erl"},{line,1139}]},
                      {io_lib_pretty,print_length_list1,7,
                                     [{file,"io_lib_pretty.erl"},{line,1058}]},
                      {io_lib_pretty,print_length_list1,7,
                                     [{file,"io_lib_pretty.erl"},{line,1059}]},
                      {io_lib_pretty,print_length_list,7,
                                     [{file,"io_lib_pretty.erl"},{line,1043}]},
                      {io_lib_pretty,print_length,7,
                                     [{file,"io_lib_pretty.erl"},
                                      {line,906}]}]},
 {initial_call,{proc_lib,init_p,5}},
 {message_queue_len,5479},
 {registered_name,ra_jms_queues_log_wal},
 {status,running},
 {stack_size,443},

...

0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0... \ny(9)     Catch 0x000070608720a8e9 (logger_backend:call_handlers/3 + 665)\n\n0x0000705ce667de68 Return addr 0x0000706087248774 (proc_lib:exit_p/3 + 364)\ny(0)     [{gen_batch_server,handle_batch_result,3,[{file,\"src/gen_batch_server.erl\"},{line,424}]},{gen_batch_server,loop_batched,2,[{file,\"src/gen_batch_server.erl\"},{line,354}]},{proc_lib,init_p_do_apply,3,[{file,\"proc_lib.erl\"},{line,333}]}]\ny(1)     chaos\ny(2)     exit\n\n0x0000705ce667de88 Return addr 0x0000706087001248 (<terminate process normally>)\n">>}]
```